### PR TITLE
Overflow in update_vesting_schedules mitigated

### DIFF
--- a/vesting/src/lib.rs
+++ b/vesting/src/lib.rs
@@ -321,7 +321,7 @@ impl<T: Config> Pallet<T> {
 			Zero::zero(),
 			|acc_amount, schedule| {
 				let amount = Self::ensure_valid_vesting_schedule(schedule)?;
-				Ok(acc_amount + amount)
+				Ok(acc_amount.saturating_add(amount))
 			},
 		)?;
 		ensure!(


### PR DESCRIPTION
An overflow in update_vesting_schedules in ORML vesting
pallet leads to a crash for nodes running in debug mode
and possibly financial loss for token creators.