### PR TITLE
Update ORML 

### DIFF
--- a/auction/Cargo.toml
+++ b/auction/Cargo.toml
@@ -10,16 +10,16 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate",  default-features = false }
 orml-traits = { path = "../traits", version = "0.4.1-dev", default-features = false }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
+sp-core = { git = "https://github.com/paritytech/substrate" }
+sp-io = { git = "https://github.com/paritytech/substrate" }
 
 [features]
 default = ["std"]

--- a/authority/Cargo.toml
+++ b/authority/Cargo.toml
@@ -10,17 +10,17 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-pallet-scheduler = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
+sp-io = { git = "https://github.com/paritytech/substrate" }
+sp-core = { git = "https://github.com/paritytech/substrate" }
+pallet-scheduler = { git = "https://github.com/paritytech/substrate" }
 
 [features]
 default = ["std"]

--- a/bencher/Cargo.toml
+++ b/bencher/Cargo.toml
@@ -21,16 +21,16 @@ linregress = { version = "0.4.0", optional = true }
 serde = { version = "1.0.119", optional = true, features = ['derive'] }
 serde_json = {version = "1.0.64", optional = true }
 codec = { package = "parity-scale-codec", version = "2.2.0", features = ["derive"], default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-runtime-interface = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false, optional = true }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false, features = ["wasmtime"], optional = true }
-sc-executor-common = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", optional = true }
-sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false, features = ["with-kvdb-rocksdb"], optional = true }
-sp-maybe-compressed-blob = { git = "https://github.com/paritytech/substrate",  branch = "polkadot-v0.9.9", default-features = false, optional = true }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-runtime-interface = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-state-machine = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true }
+sc-executor = { git = "https://github.com/paritytech/substrate",  default-features = false, features = ["wasmtime"], optional = true }
+sc-executor-common = { git = "https://github.com/paritytech/substrate", optional = true }
+sc-client-db = { git = "https://github.com/paritytech/substrate",  default-features = false, features = ["with-kvdb-rocksdb"], optional = true }
+sp-maybe-compressed-blob = { git = "https://github.com/paritytech/substrate",   default-features = false, optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
 [features]
 default = ["std"]

--- a/benchmarking/Cargo.toml
+++ b/benchmarking/Cargo.toml
@@ -11,17 +11,17 @@ edition = "2018"
 serde = { version = "1.0.124", optional = true }
 paste = "1.0"
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-runtime-interface = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-storage = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-runtime-interface = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-storage = { git = "https://github.com/paritytech/substrate",  default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
 [dev-dependencies]
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
+frame-system = { git = "https://github.com/paritytech/substrate" }
 hex-literal = "0.2.1"
 
 [features]

--- a/benchmarking/src/lib.rs
+++ b/benchmarking/src/lib.rs
@@ -7,7 +7,7 @@ mod tests;
 
 pub use frame_benchmarking::{
 	benchmarking, whitelisted_caller, BenchmarkBatch, BenchmarkConfig, BenchmarkList, BenchmarkMetadata,
-	BenchmarkParameter, BenchmarkResults, Benchmarking, BenchmarkingSetup,
+	BenchmarkParameter, BenchmarkResult, Benchmarking, BenchmarkingSetup,
 };
 #[cfg(feature = "std")]
 pub use frame_benchmarking::{Analysis, BenchmarkSelector};
@@ -626,7 +626,7 @@ macro_rules! benchmark_backend {
 // Every variant must implement [`BenchmarkingSetup`].
 //
 // ```nocompile
-// 
+//
 // struct Transfer;
 // impl BenchmarkingSetup for Transfer { ... }
 //
@@ -692,7 +692,7 @@ macro_rules! impl_benchmark {
 	) => {
 		pub struct Benchmark;
 
-		impl $crate::Benchmarking<$crate::BenchmarkResults> for Benchmark {
+		impl $crate::Benchmarking<$crate::BenchmarkResult> for Benchmark {
 			fn benchmarks(extra: bool) -> $crate::Vec<$crate::BenchmarkMetadata> {
 				let mut all_names = $crate::vec![ $( stringify!($name).as_ref() ),* ];
 				if !extra {
@@ -721,7 +721,7 @@ macro_rules! impl_benchmark {
 				whitelist: &[$crate::TrackedStorageKey],
 				verify: bool,
 				internal_repeats: u32,
-			) -> Result<$crate::Vec<$crate::BenchmarkResults>, &'static str> {
+			) -> Result<$crate::Vec<$crate::BenchmarkResult>, &'static str> {
 				// Map the input to the selected benchmark.
 				let extrinsic = $crate::sp_std::str::from_utf8(extrinsic)
 					.map_err(|_| "`extrinsic` is not a valid utf8 string!")?;
@@ -739,7 +739,7 @@ macro_rules! impl_benchmark {
 				whitelist.push(whitelisted_caller_key.into());
 				$crate::benchmarking::set_whitelist(whitelist);
 
-				let mut results: $crate::Vec<$crate::BenchmarkResults> = $crate::Vec::new();
+				let mut results: $crate::Vec<$crate::BenchmarkResult> = $crate::Vec::new();
 
 				// Always do at least one internal repeat...
 				for _ in 0 .. internal_repeats.max(1) {
@@ -807,7 +807,7 @@ macro_rules! impl_benchmark {
 						$crate::benchmarking::get_read_and_written_keys()
 					};
 
-					results.push($crate::BenchmarkResults {
+					results.push($crate::BenchmarkResult {
 						components: c.to_vec(),
 						extrinsic_time: elapsed_extrinsic,
 						storage_root_time: elapsed_storage_root,

--- a/currencies/Cargo.toml
+++ b/currencies/Cargo.toml
@@ -10,20 +10,20 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
 orml-traits = { path = "../traits", version = "0.4.1-dev", default-features = false }
 orml-utilities = { path = "../utilities", version = "0.4.1-dev", default-features = false }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-orml_tokens = { package = "orml-tokens", path = "../tokens", version = "0.4.1-dev" }
+sp-core = { git = "https://github.com/paritytech/substrate"}
+pallet-balances = { git = "https://github.com/paritytech/substrate" }
+orml_tokens = { package = "orml-tokens", path = "../tokens"}
 
 [features]
 default = ["std"]

--- a/gradually-update/Cargo.toml
+++ b/gradually-update/Cargo.toml
@@ -10,12 +10,12 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["max-encoded-len"] }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
 [features]
 default = ["std"]

--- a/nft/Cargo.toml
+++ b/nft/Cargo.toml
@@ -10,15 +10,15 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["max-encoded-len"] }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
+sp-io = { git = "https://github.com/paritytech/substrate" }
+sp-core = { git = "https://github.com/paritytech/substrate" }
 
 [features]
 default = ["std"]

--- a/oracle/Cargo.toml
+++ b/oracle/Cargo.toml
@@ -10,19 +10,19 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false }
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
 orml-traits = { path = "../traits", version = "0.4.1-dev", default-features = false }
 orml-utilities = { path = "../utilities", version = "0.4.1-dev", default-features = false }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
 [features]
 default = ["std"]

--- a/oracle/rpc/Cargo.toml
+++ b/oracle/rpc/Cargo.toml
@@ -11,8 +11,8 @@ codec = { package = "parity-scale-codec", version = "2.2.0" }
 jsonrpc-core = "15.0.0"
 jsonrpc-core-client = "15.0.0"
 jsonrpc-derive = "15.0.0"
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
+sp-runtime = { git = "https://github.com/paritytech/substrate" }
+sp-api = { git = "https://github.com/paritytech/substrate" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate" }
 
 orml-oracle-rpc-runtime-api = { path = "runtime-api", version = "0.4.1-dev" }

--- a/oracle/rpc/runtime-api/Cargo.toml
+++ b/oracle/rpc/runtime-api/Cargo.toml
@@ -8,8 +8,8 @@ description = "Runtime API module for orml-oracle-rpc."
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive"] }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
 [features]
 default = ["std"]

--- a/rewards/Cargo.toml
+++ b/rewards/Cargo.toml
@@ -10,15 +10,15 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["max-encoded-len"] }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate",  default-features = false }
 orml-traits = { path = "../traits", version = "0.4.1-dev", default-features = false }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
+sp-core = { git = "https://github.com/paritytech/substrate" }
 
 [features]
 default = ["std"]

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -10,19 +10,17 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["max-encoded-len"] }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-support = {  git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-system = {  git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
+frame-support = {  git = "https://github.com/paritytech/substrate", default-features = false }
+frame-system = {  git = "https://github.com/paritytech/substrate",  default-features = false }
 orml-traits = { path = "../traits", version = "0.4.1-dev", default-features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-# Patch doesn't work as `pallet-elections-phragmen` is now 4.0.0 version. Revert `rev` to `statemint` branch after
-# other `statemint` dependencies upgraded.
-pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", rev = "1d04678e20555e623c974ee1127bc8a45abcf3d6" }
+sp-io = { git = "https://github.com/paritytech/substrate" }
+sp-core = { git = "https://github.com/paritytech/substrate" }
+pallet-treasury = { git = "https://github.com/paritytech/substrate" }
+pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate" }
 
 [features]
 default = ["std"]

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -10,14 +10,14 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
 num-traits = { version = "0.2.14", default-features = false }
 impl-trait-for-tuples = "0.2.1"
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false }
 orml-utilities = { path = "../utilities", version = "0.4.1-dev", default-features = false }
-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.9", default-features = false }
+xcm = { git = "https://github.com/paritytech/polkadot",  default-features = false }
 
 [features]
 default = ["std"]

--- a/unknown-tokens/Cargo.toml
+++ b/unknown-tokens/Cargo.toml
@@ -10,18 +10,18 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.9", default-features = false }
+xcm = { git = "https://github.com/paritytech/polkadot", default-features = false }
 
 orml-xcm-support = { path = "../xcm-support", default-features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
+sp-io = { git = "https://github.com/paritytech/substrate" }
+sp-core = { git = "https://github.com/paritytech/substrate" }
+sp-runtime = { git = "https://github.com/paritytech/substrate" }
 
 [features]
 default = ["std"]

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -10,14 +10,14 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.64"
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
+frame-system = { git = "https://github.com/paritytech/substrate" }
 
 [features]
 default = ["std"]

--- a/vesting/Cargo.toml
+++ b/vesting/Cargo.toml
@@ -10,16 +10,16 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["max-encoded-len"] }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
+sp-core = { git = "https://github.com/paritytech/substrate" }
+pallet-balances = { git = "https://github.com/paritytech/substrate" }
 
 [features]
 default = ["std"]

--- a/weight-meter/Cargo.toml
+++ b/weight-meter/Cargo.toml
@@ -10,20 +10,20 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 spin = "0.7.1"
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false }
 weight-meter-procedural = { path = "weight-meter-procedural", default-features = false }
 orml-bencher = { path = "../bencher", default-features = false, optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.124" }
 codec = { package = "parity-scale-codec", version = "2.2.0" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
+sp-runtime = { git = "https://github.com/paritytech/substrate" }
+sp-io = { git = "https://github.com/paritytech/substrate" }
+sp-std = { git = "https://github.com/paritytech/substrate" }
 
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9"}
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
+frame-system = { git = "https://github.com/paritytech/substrate" }
+pallet-balances = { git = "https://github.com/paritytech/substrate" }
 
 [features]
 default = ["std"]

--- a/xcm-support/Cargo.toml
+++ b/xcm-support/Cargo.toml
@@ -10,13 +10,13 @@ edition = "2018"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false }
 
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.9", default-features = false }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.9", default-features = false }
+xcm = { git = "https://github.com/paritytech/polkadot",  default-features = false }
+xcm-executor = { git = "https://github.com/paritytech/polkadot",  default-features = false }
 
 orml-traits = { path = "../traits", version = "0.4.1-dev", default-features = false }
 

--- a/xcm/Cargo.toml
+++ b/xcm/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false }
 
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.9", default-features = false }
-pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.9", default-features = false }
+xcm = { git = "https://github.com/paritytech/polkadot",  default-features = false }
+pallet-xcm = { git = "https://github.com/paritytech/polkadot",  default-features = false }
 
 [features]
 default = ["std"]

--- a/xtokens/Cargo.toml
+++ b/xtokens/Cargo.toml
@@ -10,31 +10,31 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate",  default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate",  default-features = false }
 
-cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.9", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", default-features = false }
 
-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.9", default-features = false }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.9", default-features = false }
+xcm = { git = "https://github.com/paritytech/polkadot",  default-features = false }
+xcm-executor = { git = "https://github.com/paritytech/polkadot",  default-features = false }
 
 orml-xcm-support = { path = "../xcm-support", default-features = false }
 orml-traits = { path = "../traits", default-features = false}
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
+sp-core = { git = "https://github.com/paritytech/substrate" }
+pallet-balances = { git = "https://github.com/paritytech/substrate" }
 
 # cumulus
-cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.9" }
-cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.9" }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.9" }
-cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.9" }
-parachain-info = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.9" }
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus"}
+cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus"}
+cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus"}
+cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus"}
+parachain-info = { git = "https://github.com/paritytech/cumulus"}
 
 # polkadot
 polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.9" }

--- a/xtokens/src/mock.rs
+++ b/xtokens/src/mock.rs
@@ -1,0 +1,470 @@
+#![cfg(test)]
+
+use super::*;
+use crate as orml_xtokens;
+
+use frame_support::parameter_types;
+use orml_traits::parameter_type_with_key;
+use orml_xcm_support::{IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset, XcmHandler as XcmHandlerT};
+use polkadot_parachain::primitives::Sibling;
+use serde::{Deserialize, Serialize};
+use sp_io::TestExternalities;
+use sp_runtime::AccountId32;
+use xcm::v0::{Junction, MultiLocation::*, NetworkId};
+use xcm_builder::{
+	AccountId32Aliases, LocationInverter, ParentIsDefault, RelayChainAsNative, SiblingParachainAsNative,
+	SiblingParachainConvertsVia, SignedAccountId32AsNative, SovereignSignedViaLocation,
+};
+use xcm_executor::Config as XcmConfigT;
+use xcm_simulator::{decl_test_network, decl_test_parachain, prelude::*};
+
+pub const ALICE: AccountId32 = AccountId32::new([0u8; 32]);
+pub const BOB: AccountId32 = AccountId32::new([1u8; 32]);
+
+#[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, PartialOrd, Ord)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum CurrencyId {
+	/// Relay chain token.
+	R,
+	/// Parachain A token.
+	A,
+	/// Parachain B token.
+	B,
+}
+
+pub struct CurrencyIdConvert;
+impl Convert<CurrencyId, Option<MultiLocation>> for CurrencyIdConvert {
+	fn convert(id: CurrencyId) -> Option<MultiLocation> {
+		match id {
+			CurrencyId::R => Some(Junction::Parent.into()),
+			CurrencyId::A => Some(
+				(
+					Junction::Parent,
+					Junction::Parachain { id: 1 },
+					Junction::GeneralKey("A".into()),
+				)
+					.into(),
+			),
+			CurrencyId::B => Some(
+				(
+					Junction::Parent,
+					Junction::Parachain { id: 2 },
+					Junction::GeneralKey("B".into()),
+				)
+					.into(),
+			),
+		}
+	}
+}
+impl Convert<MultiLocation, Option<CurrencyId>> for CurrencyIdConvert {
+	fn convert(l: MultiLocation) -> Option<CurrencyId> {
+		let a: Vec<u8> = "A".into();
+		let b: Vec<u8> = "B".into();
+		match l {
+			X1(Parent) => Some(CurrencyId::R),
+			X3(Junction::Parent, Junction::Parachain { id: 1 }, Junction::GeneralKey(k)) if k == a => {
+				Some(CurrencyId::A)
+			}
+			X3(Junction::Parent, Junction::Parachain { id: 2 }, Junction::GeneralKey(k)) if k == b => {
+				Some(CurrencyId::B)
+			}
+			_ => None,
+		}
+	}
+}
+impl Convert<MultiAsset, Option<CurrencyId>> for CurrencyIdConvert {
+	fn convert(a: MultiAsset) -> Option<CurrencyId> {
+		if let MultiAsset::ConcreteFungible { id, amount: _ } = a {
+			Self::convert(id)
+		} else {
+			None
+		}
+	}
+}
+
+pub type Balance = u128;
+pub type Amount = i128;
+
+decl_test_parachain! {
+	pub struct ParaA {
+		new_ext = parachain_ext::<para_a::Runtime>(1),
+		para_id = 1,
+	}
+	pub mod para_a {
+		test_network = super::TestNetwork,
+		xcm_config = {
+			use super::*;
+
+			parameter_types! {
+				pub ParaANetwork: NetworkId = NetworkId::Any;
+				pub RelayChainOrigin: Origin = cumulus_pallet_xcm_handler::Origin::Relay.into();
+				pub Ancestry: MultiLocation = MultiLocation::X1(Junction::Parachain {
+					id: ParachainInfo::get().into(),
+				});
+				pub const RelayChainCurrencyId: CurrencyId = CurrencyId::R;
+			}
+
+			pub type LocationConverter = (
+				ParentIsDefault<AccountId>,
+				SiblingParachainConvertsVia<Sibling, AccountId>,
+				AccountId32Aliases<ParaANetwork, AccountId>,
+			);
+
+			pub type LocalAssetTransactor = MultiCurrencyAdapter<
+				Tokens,
+				(),
+				IsNativeConcrete<CurrencyId, CurrencyIdConvert>,
+				AccountId,
+				LocationConverter,
+				CurrencyId,
+				CurrencyIdConvert,
+			>;
+
+			pub type LocalOriginConverter = (
+				SovereignSignedViaLocation<LocationConverter, Origin>,
+				RelayChainAsNative<RelayChainOrigin, Origin>,
+				SiblingParachainAsNative<cumulus_pallet_xcm_handler::Origin, Origin>,
+				SignedAccountId32AsNative<ParaANetwork, Origin>,
+			);
+
+			pub struct XcmConfig;
+			impl XcmConfigT for XcmConfig {
+				type Call = Call;
+				type XcmSender = XcmHandler;
+				type AssetTransactor = LocalAssetTransactor;
+				type OriginConverter = LocalOriginConverter;
+				type IsReserve = MultiNativeAsset;
+				type IsTeleporter = ();
+				type LocationInverter = LocationInverter<Ancestry>;
+			}
+		},
+		extra_config = {
+			parameter_type_with_key! {
+				pub ExistentialDeposits: |_currency_id: super::CurrencyId| -> Balance {
+					Default::default()
+				};
+			}
+
+			impl orml_tokens::Config for Runtime {
+				type Event = Event;
+				type Balance = Balance;
+				type Amount = Amount;
+				type CurrencyId = super::CurrencyId;
+				type WeightInfo = ();
+				type ExistentialDeposits = ExistentialDeposits;
+				type OnDust = ();
+			}
+
+			pub struct HandleXcm;
+			impl XcmHandlerT<AccountId> for HandleXcm {
+				fn execute_xcm(origin: AccountId, xcm: Xcm) -> DispatchResult {
+					XcmHandler::execute_xcm(origin, xcm)
+				}
+			}
+
+			pub struct AccountId32Convert;
+			impl Convert<AccountId, [u8; 32]> for AccountId32Convert {
+				fn convert(account_id: AccountId) -> [u8; 32] {
+					account_id.into()
+				}
+			}
+
+			parameter_types! {
+				pub SelfLocation: MultiLocation = (Junction::Parent, Junction::Parachain { id: ParachainInfo::get().into() }).into();
+			}
+
+			impl orml_xtokens::Config for Runtime {
+				type Event = Event;
+				type Balance = Balance;
+				type CurrencyId = CurrencyId;
+				type CurrencyIdConvert = CurrencyIdConvert;
+				type AccountId32Convert = AccountId32Convert;
+				type SelfLocation = SelfLocation;
+				type XcmHandler = HandleXcm;
+			}
+		},
+		extra_modules = {
+			Tokens: orml_tokens::{Pallet, Storage, Event<T>, Config<T>},
+			XTokens: orml_xtokens::{Pallet, Storage, Call, Event<T>},
+		},
+	}
+}
+
+decl_test_parachain! {
+	pub struct ParaB {
+		new_ext = parachain_ext::<para_b::Runtime>(2),
+		para_id = 2,
+	}
+	pub mod para_c {
+		test_network = super::TestNetwork,
+		xcm_config = {
+			use super::*;
+
+			parameter_types! {
+				pub ParaANetwork: NetworkId = NetworkId::Any;
+				pub RelayChainOrigin: Origin = cumulus_pallet_xcm_handler::Origin::Relay.into();
+				pub Ancestry: MultiLocation = MultiLocation::X1(Junction::Parachain {
+					id: ParachainInfo::get().into(),
+				});
+				pub const RelayChainCurrencyId: CurrencyId = CurrencyId::R;
+			}
+
+			pub type LocationConverter = (
+				ParentIsDefault<AccountId>,
+				SiblingParachainConvertsVia<Sibling, AccountId>,
+				AccountId32Aliases<ParaANetwork, AccountId>,
+			);
+
+			pub type LocalAssetTransactor = MultiCurrencyAdapter<
+				Tokens,
+				(),
+				IsNativeConcrete<CurrencyId, CurrencyIdConvert>,
+				AccountId,
+				LocationConverter,
+				CurrencyId,
+				CurrencyIdConvert,
+			>;
+
+			pub type LocalOriginConverter = (
+				SovereignSignedViaLocation<LocationConverter, Origin>,
+				RelayChainAsNative<RelayChainOrigin, Origin>,
+				SiblingParachainAsNative<cumulus_pallet_xcm_handler::Origin, Origin>,
+				SignedAccountId32AsNative<ParaANetwork, Origin>,
+			);
+
+			pub struct XcmConfig;
+			impl XcmConfigT for XcmConfig {
+				type Call = Call;
+				type XcmSender = XcmHandler;
+				type AssetTransactor = LocalAssetTransactor;
+				type OriginConverter = LocalOriginConverter;
+				type IsReserve = MultiNativeAsset;
+				type IsTeleporter = ();
+				type LocationInverter = LocationInverter<Ancestry>;
+			}
+		},
+		extra_config = {
+			parameter_type_with_key! {
+				pub ExistentialDeposits: |_currency_id: super::CurrencyId| -> Balance {
+					Default::default()
+				};
+			}
+
+			impl orml_tokens::Config for Runtime {
+				type Event = Event;
+				type Balance = Balance;
+				type Amount = Amount;
+				type CurrencyId = super::CurrencyId;
+				type WeightInfo = ();
+				type ExistentialDeposits = ExistentialDeposits;
+				type OnDust = ();
+			}
+
+			pub struct HandleXcm;
+			impl XcmHandlerT<AccountId> for HandleXcm {
+				fn execute_xcm(origin: AccountId, xcm: Xcm) -> DispatchResult {
+					XcmHandler::execute_xcm(origin, xcm)
+				}
+			}
+
+			pub struct AccountId32Convert;
+			impl Convert<AccountId, [u8; 32]> for AccountId32Convert {
+				fn convert(account_id: AccountId) -> [u8; 32] {
+					account_id.into()
+				}
+			}
+
+			parameter_types! {
+				pub SelfLocation: MultiLocation = (Junction::Parent, Junction::Parachain { id: ParachainInfo::get().into() }).into();
+			}
+
+			impl orml_xtokens::Config for Runtime {
+				type Event = Event;
+				type Balance = Balance;
+				type CurrencyId = CurrencyId;
+				type CurrencyIdConvert = CurrencyIdConvert;
+				type AccountId32Convert = AccountId32Convert;
+				type SelfLocation = SelfLocation;
+				type XcmHandler = HandleXcm;
+			}
+		},
+		extra_modules = {
+			Tokens: orml_tokens::{Pallet, Storage, Event<T>, Config<T>},
+			XTokens: orml_xtokens::{Pallet, Storage, Call, Event<T>},
+		},
+	}
+}
+
+decl_test_parachain! {
+	pub struct ParaC {
+		new_ext = parachain_ext::<para_b::Runtime>(3),
+		para_id = 3,
+	}
+	pub mod para_b {
+		test_network = super::TestNetwork,
+		xcm_config = {
+			use super::*;
+
+			parameter_types! {
+				pub ParaANetwork: NetworkId = NetworkId::Any;
+				pub RelayChainOrigin: Origin = cumulus_pallet_xcm_handler::Origin::Relay.into();
+				pub Ancestry: MultiLocation = MultiLocation::X1(Junction::Parachain {
+					id: ParachainInfo::get().into(),
+				});
+				pub const RelayChainCurrencyId: CurrencyId = CurrencyId::R;
+			}
+
+			pub type LocationConverter = (
+				ParentIsDefault<AccountId>,
+				SiblingParachainConvertsVia<Sibling, AccountId>,
+				AccountId32Aliases<ParaANetwork, AccountId>,
+			);
+
+			pub type LocalAssetTransactor = MultiCurrencyAdapter<
+				Tokens,
+				(),
+				IsNativeConcrete<CurrencyId, CurrencyIdConvert>,
+				AccountId,
+				LocationConverter,
+				CurrencyId,
+				CurrencyIdConvert,
+			>;
+
+			pub type LocalOriginConverter = (
+				SovereignSignedViaLocation<LocationConverter, Origin>,
+				RelayChainAsNative<RelayChainOrigin, Origin>,
+				SiblingParachainAsNative<cumulus_pallet_xcm_handler::Origin, Origin>,
+				SignedAccountId32AsNative<ParaANetwork, Origin>,
+			);
+
+			pub struct XcmConfig;
+			impl XcmConfigT for XcmConfig {
+				type Call = Call;
+				type XcmSender = XcmHandler;
+				type AssetTransactor = LocalAssetTransactor;
+				type OriginConverter = LocalOriginConverter;
+				type IsReserve = MultiNativeAsset;
+				type IsTeleporter = ();
+				type LocationInverter = LocationInverter<Ancestry>;
+			}
+		},
+		extra_config = {
+			parameter_type_with_key! {
+				pub ExistentialDeposits: |_currency_id: super::CurrencyId| -> Balance {
+					Default::default()
+				};
+			}
+
+			impl orml_tokens::Config for Runtime {
+				type Event = Event;
+				type Balance = Balance;
+				type Amount = Amount;
+				type CurrencyId = super::CurrencyId;
+				type WeightInfo = ();
+				type ExistentialDeposits = ExistentialDeposits;
+				type OnDust = ();
+			}
+
+			pub struct HandleXcm;
+			impl XcmHandlerT<AccountId> for HandleXcm {
+				fn execute_xcm(origin: AccountId, xcm: Xcm) -> DispatchResult {
+					XcmHandler::execute_xcm(origin, xcm)
+				}
+			}
+
+			pub struct AccountId32Convert;
+			impl Convert<AccountId, [u8; 32]> for AccountId32Convert {
+				fn convert(account_id: AccountId) -> [u8; 32] {
+					account_id.into()
+				}
+			}
+
+			parameter_types! {
+				pub SelfLocation: MultiLocation = (Junction::Parent, Junction::Parachain { id: ParachainInfo::get().into() }).into();
+			}
+
+			impl orml_xtokens::Config for Runtime {
+				type Event = Event;
+				type Balance = Balance;
+				type CurrencyId = CurrencyId;
+				type CurrencyIdConvert = CurrencyIdConvert;
+				type AccountId32Convert = AccountId32Convert;
+				type SelfLocation = SelfLocation;
+				type XcmHandler = HandleXcm;
+			}
+		},
+		extra_modules = {
+			Tokens: orml_tokens::{Pallet, Storage, Event<T>, Config<T>},
+			XTokens: orml_xtokens::{Pallet, Storage, Call, Event<T>},
+		},
+	}
+}
+
+decl_test_network! {
+	pub struct TestNetwork {
+		relay_chain = default,
+		parachains = vec![
+			(1, ParaA),
+			(2, ParaB),
+			(3, ParaC),
+		],
+	}
+}
+
+pub type ParaAXtokens = orml_xtokens::Pallet<para_a::Runtime>;
+pub type ParaATokens = orml_tokens::Pallet<para_a::Runtime>;
+pub type ParaBTokens = orml_tokens::Pallet<para_b::Runtime>;
+pub type ParaCTokens = orml_tokens::Pallet<para_c::Runtime>;
+
+pub type RelayBalances = pallet_balances::Pallet<relay::Runtime>;
+
+pub struct ParaExtBuilder;
+
+impl Default for ParaExtBuilder {
+	fn default() -> Self {
+		ParaExtBuilder
+	}
+}
+
+impl ParaExtBuilder {
+	pub fn build<
+		Runtime: frame_system::Config<AccountId = AccountId32> + orml_tokens::Config<CurrencyId = CurrencyId, Balance = Balance>,
+	>(
+		self,
+		para_id: u32,
+	) -> TestExternalities
+	where
+		<Runtime as frame_system::Config>::BlockNumber: From<u64>,
+	{
+		let mut t = frame_system::GenesisConfig::default()
+			.build_storage::<Runtime>()
+			.unwrap();
+
+		parachain_info::GenesisConfig {
+			parachain_id: para_id.into(),
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+
+		orml_tokens::GenesisConfig::<Runtime> {
+			endowed_accounts: vec![(ALICE, CurrencyId::R, 100)],
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+
+		let mut ext = TestExternalities::new(t);
+		ext.execute_with(|| frame_system::Pallet::<Runtime>::set_block_number(1.into()));
+		ext
+	}
+}
+
+pub fn parachain_ext<
+	Runtime: frame_system::Config<AccountId = AccountId32> + orml_tokens::Config<CurrencyId = CurrencyId, Balance = Balance>,
+>(
+	para_id: u32,
+) -> TestExternalities
+where
+	<Runtime as frame_system::Config>::BlockNumber: From<u64>,
+{
+	ParaExtBuilder::default().build::<Runtime>(para_id)
+}


### PR DESCRIPTION
This PR updates ORML with latest changes from upstream ORML repo and it also changes the dependencies to point at substrate master rather than a specific commit, this makes it easier down the lane to upgrade and downgrade using `cargo update -p sp-io --precise <commit-required>` 